### PR TITLE
Added TFIDF preprocessor

### DIFF
--- a/ktrain/tests/test_dataloading.py
+++ b/ktrain/tests/test_dataloading.py
@@ -79,6 +79,14 @@ class TestTextData(TestCase):
         (trn, val, preproc)  = texts_from_csv()
         self.__test_texts_standard(trn, val, preproc)
 
+    def test_texts_from_folder_tfidf(self):
+        (trn, val, preproc)  = texts_from_folder(preprocess_mode='tfidf')
+        self.__test_texts_tfidf(trn, val, preproc)
+
+
+    def test_texts_from_csv_tfidf(self):
+        (trn, val, preproc)  = texts_from_csv(preprocess_mode='tfidf')
+        self.__test_texts_tfidf(trn, val, preproc)
 
     def test_texts_from_folder_bert(self):
         (trn, val, preproc)  = texts_from_folder(preprocess_mode='bert')
@@ -108,6 +116,25 @@ class TestTextData(TestCase):
         self.assertEqual(preproc.preprocess(['hello book'])[0][-1], 1)
         self.assertEqual(preproc.preprocess(['hello book']).shape, (1, 10))
         self.assertEqual(preproc.undo(val[0][0]), 'the book is bad')
+
+    def __test_texts_tfidf(self, trn, val, preproc):
+        self.assertFalse(U.is_iter(trn))
+        self.assertEqual(trn[0].shape, (4, 100))
+        self.assertEqual(trn[1].shape, (4, 2))
+        self.assertEqual(val[0].shape, (4, 100))
+        self.assertEqual(val[1].shape, (4, 2))
+        self.assertFalse(U.is_multilabel(trn))
+        self.assertEqual(U.shape_from_data(trn), (4, 100))
+        self.assertFalse(U.ondisk(trn))
+        self.assertEqual(U.nsamples_from_data(trn), 4)
+        self.assertEqual(U.nclasses_from_data(trn), 2)
+        self.assertEqual(U.y_from_data(trn).shape, (4,2))
+        self.assertFalse(U.bert_data_tuple(trn))
+        self.assertEqual(preproc.get_classes(), ['neg', 'pos'])
+        self.assertEqual(preproc.ngram_count(), 1)
+        self.assertEqual('%.4f'%(preproc.preprocess(['hello book'])[0][1]),  '0.5878')
+        self.assertEqual(preproc.preprocess(['hello book']).shape, (1, 100))
+        self.assertEqual(preproc.undo(val[0][0]), 'book is the bad')
 
 
     def __test_texts_bert(self, trn, val, preproc):

--- a/ktrain/text/preprocessor.py
+++ b/ktrain/text/preprocessor.py
@@ -448,7 +448,7 @@ class TFIDFTextPreprocessor(StandardTextPreprocessor):
         test_text = self.process_chinese(test_text, self.lang)
 
         # convert to word IDs
-        x_test = self.tok.texts_to_matrix(train_text, mode='tfidf')
+        x_test = self.tok.texts_to_matrix(test_text, mode='tfidf')
         U.vprint('{} test sequences'.format(len(x_test)), verbose=verbose)
         U.vprint('Average test sequence length: {}'.format(np.mean(list(map(len, x_test)), 
                                                                  dtype=int)), verbose=verbose)

--- a/ktrain/text/preprocessor.py
+++ b/ktrain/text/preprocessor.py
@@ -399,6 +399,16 @@ class StandardTextPreprocessor(TextPreprocessor):
 
 class TFIDFTextPreprocessor(StandardTextPreprocessor):
 
+    def undo(self, doc):
+        """
+        undoes preprocessing and returns raw data by:
+        converting a list or array of Word IDs back to words
+        """
+        dct = self.tok.index_word
+        return " ".join([dct[wid] for wid in range(len(doc)) if doc[wid] != 0 and wid in dct])
+
+
+
     def preprocess_train(self, train_text, y_train, verbose=1):
         """
         preprocess training set
@@ -422,7 +432,7 @@ class TFIDFTextPreprocessor(StandardTextPreprocessor):
         U.vprint('Average train sequence length: {}'.format(np.mean(list(map(len, x_train)), dtype=int)), verbose=verbose)
 
         # add ngrams
-        x_train = self._fit_ngrams(x_train, verbose=verbose)
+        #x_train = self._fit_ngrams(x_train, verbose=verbose)
 
         # pad sequences
         #x_train = sequence.pad_sequences(x_train, maxlen=self.maxlen)
@@ -454,7 +464,7 @@ class TFIDFTextPreprocessor(StandardTextPreprocessor):
                                                                  dtype=int)), verbose=verbose)
 
         # add n-grams
-        x_test = self._add_ngrams(x_test, mode='test', verbose=verbose)
+        #x_test = self._add_ngrams(x_test, mode='test', verbose=verbose)
 
 
         # pad sequences


### PR DESCRIPTION
Using the same preprocessing pipeline, namely keras.preprocessing.text.Tokenizer I have added a TFIDF based preprocessing mode `texts_to_matrix(..., mode='tfidf')`.
Testing is OKish - since this is a BOW approach, had to modify the assertion by text undo to accommodate this.

What is still missing is the ngram support. Could not add this now.

Hope you might find this interesting!