### PR TITLE
Fix repeated word in progress output

### DIFF
--- a/ktrain/text/preprocessor.py
+++ b/ktrain/text/preprocessor.py
@@ -34,7 +34,7 @@ def get_wv_path():
         U.download(WV_URL, zip_fpath)
 
         # unzip
-        print('\nextracting pretrained pretrained word vectors...')
+        print('\nextracting pretrained word vectors...')
         with zipfile.ZipFile(zip_fpath, 'r') as zip_ref:
             zip_ref.extractall(ktrain_data)
         print('done.\n')


### PR DESCRIPTION
When downloading word vectors, output shows:
`extracting pretrained pretrained word vectors...`
rather than the desired:
`extracting pretrained word vectors...`
