### PR TITLE
Config for BertJapaneseTokenizer

### DIFF
--- a/ktrain/text/preprocessor.py
+++ b/ktrain/text/preprocessor.py
@@ -719,6 +719,8 @@ class TransformersPreprocessor(TextPreprocessor):
             raise ValueError('uknown model name %s' % (model_name))
         self.model_type = TRANSFORMER_MODELS[self.name][1]
         self.tokenizer_type = TRANSFORMER_MODELS[self.name][2]
+        if "bert-base-japanese" in model_name:
+            self.tokenizer_type = transformers.BertJapaneseTokenizer
 
         tokenizer = self.tokenizer_type.from_pretrained(model_name)
 
@@ -982,4 +984,3 @@ class TransformerSequence(Sequence):
 TEXT_PREPROCESSORS = {'standard': StandardTextPreprocessor,
                       'bert': BERTPreprocessor,
                       'distilbert': DistilBertPreprocessor}
-


### PR DESCRIPTION
To enable using bert-base-japanese* models.

Reference: https://github.com/huggingface/transformers/blob/master/src/transformers/tokenization_auto.py#L177-L178