### PR TITLE
Added a predict and mask function

### DIFF
--- a/ktrain/text/shallownlp/ner.py
+++ b/ktrain/text/shallownlp/ner.py
@@ -76,6 +76,23 @@ class NER:
         #else:
             #del os.environ['CUDA_VISIBLE_DEVICES']
         return result
+    
+    #Gets the entities and masks the entities if they are in the list
+    #Expect mask element in [[entitytoken, (optional) replacementtoken]]
+    #Example: [["PER", "XXX"]] or [["PER"], ["ORG", "YYY"]]
+    def predict_and_mask(self, texts, merge_tokens=True, mask_list=[]):
+        entities = self.predict(texts)
+        result = texts
+        if mask_list is not []:
+            for mask in mask_list:
+                for entity in entities:
+                    if mask[0] == entity[1]:
+                        try:
+                            result = result.replace(entity[0], mask[1])
+                        except:
+                            result = result.replace(entity[0], "XXX")
+        return result
+        
 
     def merge_entities(self, annotated_sentence):
         if self.lang == 'zh':


### PR DESCRIPTION
With this function anyone is able to mask named entities such as names or organisations. This might prove helpful for people who work with sensitive data and want to use NER to scan documents faster. 

This can also prove useful when more entities are implemented:
- ID numbers of some sort
- E-mail addresses
- Bank account number
- Telephone number
- etc.