### PR TITLE
(NER predictor) fix bug where sequence length is calculated incorrectly  leading to dimension mismatch in concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Most recent releases are shown at the top. Each release shows:
 - **Changed**: Additional parameters, changes to inputs or outputs, etc
 - **Fixed**: Bug fixes that don't change documented behaviour
 
+## 0.14.3 (TBD)
+
+### New:
+- N/A
+
+### Changed
+- N/A
+
+### Fixed:
+- run prepare for NER sequence predictor to avoid matrix mismatch
+
 
 ## 0.14.2 (TBD)
 

--- a/ktrain/text/ner/predictor.py
+++ b/ktrain/text/ner/predictor.py
@@ -33,7 +33,9 @@ class NERPredictor(Predictor):
         if not isinstance(sentence, str):
             raise ValueError('Param sentence must be a string-representation of a sentence')
         nerseq = self.preproc.preprocess([sentence])
-        nerseq.batch_size = self.batch_size 
+        if not nerseq.prepare_called:
+            nerseq.prepare()
+        nerseq.batch_size = self.batch_size
         x_true, _ = nerseq[0]
         lengths = nerseq.get_lengths(0)
         y_pred = self.model.predict_on_batch(x_true)

--- a/ktrain/version.py
+++ b/ktrain/version.py
@@ -1,2 +1,2 @@
 __all__ = ['__version__']
-__version__ = '0.14.2'
+__version__ = '0.14.3'


### PR DESCRIPTION
I had a problem when calling `predictor.predict()` on a NER model. If `nerseq.prepare()` hasn't been called, `nerseq.get_lengths(0)` returns an incorrect value for some cases. Though I haven't been able to determine what causes this mismatch, I've been able to successfully process a few hundred documents by making the changes made in this PR.

Trace of the orignal error:
```
---------------------------------------------------------------------------
InvalidArgumentError                      Traceback (most recent call last)
<ipython-input-49-01f077549ea8> in process_new_predictor(text)
      1 from collections import defaultdict
      2 def process_new_predictor(text):
----> 3     prediction = predictor.predict(text)
      4     entities = defaultdict(set)
      5     positions = []

~/.local/lib/python3.6/site-packages/ktrain/text/ner/predictor.py in predict(self, sentence)
     37         x_true, _ = nerseq[0]
     38         lengths = nerseq.get_lengths(0)
---> 39         y_pred = self.model.predict_on_batch(x_true)
     40         y_pred = self.preproc.p.inverse_transform(y_pred, lengths)
     41         y_pred = y_pred[0]

~/.local/lib/python3.6/site-packages/tensorflow_core/python/keras/engine/training.py in predict_on_batch(self, x)
   1238     self._check_call_args('predict_on_batch')
   1239     if self._experimental_run_tf_function:
-> 1240       return training_v2_utils.predict_on_batch(self, x, standalone=True)
   1241 
   1242     if (self._distribution_strategy and

~/.local/lib/python3.6/site-packages/tensorflow_core/python/keras/engine/training_v2_utils.py in predict_on_batch(model, x, standalone)
    554 
    555   with backend.eager_learning_phase_scope(0):
--> 556     return predict_on_batch_fn(inputs)  # pylint: disable=not-callable

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/def_function.py in call(self, *args, **kwds)
    566         xla_context.Exit()
    567     else:
--> 568       result = self._call(*args, **kwds)
    569 
    570     if tracing_count == self._get_tracing_count():

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/def_function.py in _call(self, *args, **kwds)
    604       # In this case we have not created variables on the first call. So we can
    605       # run the first trace but we should fail if variables are created.
--> 606       results = self._stateful_fn(*args, **kwds)
    607       if self._created_variables:
    608         raise ValueError("Creating variables on a non-first call to a function"

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/function.py in call(self, *args, **kwargs)
   2361     with self._lock:
   2362       graph_function, args, kwargs = self._maybe_define_function(args, kwargs)
-> 2363     return graph_function._filtered_call(args, kwargs)  # pylint: disable=protected-access
   2364 
   2365   @property

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/function.py in _filtered_call(self, args, kwargs)
   1609          if isinstance(t, (ops.Tensor,
   1610                            resource_variable_ops.BaseResourceVariable))),
-> 1611         self.captured_inputs)
   1612 
   1613   def _call_flat(self, args, captured_inputs, cancellation_manager=None):

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/function.py in _call_flat(self, args, captured_inputs, cancellation_manager)
   1690       # No tape is watching; skip to running the function.
   1691       return self._build_call_outputs(self._inference_function.call(
-> 1692           ctx, args, cancellation_manager=cancellation_manager))
   1693     forward_backward = self._select_forward_and_backward_functions(
   1694         args,

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/function.py in call(self, ctx, args, cancellation_manager)
    543               inputs=args,
    544               attrs=("executor_type", executor_type, "config_proto", config),
--> 545               ctx=ctx)
    546         else:
    547           outputs = execute.execute_with_cancellation(

~/.local/lib/python3.6/site-packages/tensorflow_core/python/eager/execute.py in quick_execute(op_name, num_outputs, inputs, attrs, ctx, name)
     65     else:
     66       message = e.message
---> 67     six.raise_from(core._status_to_exception(e.code, message), None)
     68   except TypeError as e:
     69     keras_symbolic_tensors = [

~/.local/lib/python3.6/site-packages/six.py in raise_from(value, from_value)

InvalidArgumentError:  ConcatOp : Dimensions of inputs should match: shape[0] = [1,273,100] vs. shape[1] = [1,275,768]
   [[node model_1/concatenate_1/concat (defined at /home/ttt/.local/lib/python3.6/site-packages/ktrain/text/ner/predictor.py:39) ]] [Op:__inference_function_24292]

Function call stack:
function
```

Please let me know if you want me to version differently.