### PR TITLE
calling lr_plot() on Learner object within Jupyter notebook plot is sometimes not displayed

### DIFF
--- a/ktrain/lroptimize/lrfinder.py
+++ b/ktrain/lroptimize/lrfinder.py
@@ -152,6 +152,7 @@ class LRFinder:
             except:
                 print("Failed to compute the gradients, there might not be enough points.\n" +\
                        "Plot displayed without suggestion.")
+                plt.show()
                 return
             else:
                 print('Two possible suggestions for LR from plot:')
@@ -159,6 +160,7 @@ class LRFinder:
                 print(f"\tMin loss divided by 10: {self.lrs[ml]/10:.2E}")
                 print(mg)
                 ax.plot(self.lrs[mg],self.losses[mg], markersize=10,marker='o',color='red')
+                plt.show()
         return
 
 


### PR DESCRIPTION
Whether or not the plot displayed appeared to be especially inconsistent if code was run inside a loop where each loop iteration should have generated a corresponding learning rate plot. In this case it appears that the plot fails to display at all.

Adding explicit plt.show() prior to return appears to resolve this issue. 

`%matplotlib inline` was included in the notebook preamble. 