### PR TITLE
Update setup.py, transformers 4.0.0 breaks the existing code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
           'bokeh',
           'seqeval==0.0.19', # pin to 0.0.19 due to numpy version incompatibility with TensorFlow 2.3
           'packaging',
-          'transformers>=3.1.0', # due to breaking change in v3.1.0
+          'transformers==3.1.0', # due to breaking change in v3.1.0
           'ipython',
           'syntok',
           'whoosh',


### PR DESCRIPTION
Keeping it >=3.1.0 installs transformers 4.0.0 which breaks the code. So probably needs a < constraint but that will need inspection.