### PR TITLE
Fix checking data type after prediction on text explanation

### DIFF
--- a/ktrain/text/predictor.py
+++ b/ktrain/text/predictor.py
@@ -120,10 +120,9 @@ class TextPredictor(Predictor):
             warnings.warn(msg)
             return
 
-
+        if not isinstance(doc, str): raise TypeError('text must of type str')
         prediction = [self.predict(doc)] if not all_targets else None
 
-        if not isinstance(doc, str): raise Exception('text must of type str')
         if self.preproc.is_nospace_lang():
             doc = self.preproc.process_chinese([doc])
             doc = doc[0]


### PR DESCRIPTION
* Also fix error when `[self.predict(doc)]` is called, but `doc` data type isn't `str`
* Replace generic exception with `TypeError` exception