### PR TITLE
Use binary cross entropy when only two classes

### DIFF
--- a/ktrain/text/preprocessor.py
+++ b/ktrain/text/preprocessor.py
@@ -978,14 +978,15 @@ class TransformersPreprocessor(TextPreprocessor):
         """
         is_regression = U.is_regression_from_data(transformer_ds)
         multilabel = U.is_multilabel(transformer_ds)
+        nclasses = U.nclasses_from_data(transformer_ds)
         model = TFAutoModelForSequenceClassification.from_pretrained(fpath)
         if is_regression:
             metrics = ['mae']
             loss_fn = 'mse'
         else:
             metrics = ['accuracy']
-            if multilabel:
-                loss_fn =  keras.losses.BinaryCrossentropy(from_logits=True)
+            if multilabel or nclasses == 2:
+                loss_fn = keras.losses.BinaryCrossentropy(from_logits=True)
             else:
                 loss_fn = keras.losses.CategoricalCrossentropy(from_logits=True)
         model.compile(loss=loss_fn,
@@ -1043,8 +1044,8 @@ class TransformersPreprocessor(TextPreprocessor):
         num_labels = len(self.get_classes())
         mname = fpath if fpath is not None else self.model_name
         model = self._load_pretrained(mname, num_labels)
-        if multilabel:
-            loss_fn =  keras.losses.BinaryCrossentropy(from_logits=True)
+        if multilabel or num_labels == 2:
+            loss_fn = keras.losses.BinaryCrossentropy(from_logits=True)
         else:
             loss_fn = keras.losses.CategoricalCrossentropy(from_logits=True)
         model.compile(loss=loss_fn,


### PR DESCRIPTION
I was trying to use ktrain in my project for binary text classification. I noticed (on a private dataset) that the model was not converging. I am mostly following the [Text Classification with Hugging Face Transformers](https://nbviewer.jupyter.org/github/amaiya/ktrain/blob/master/tutorials/tutorial-A3-hugging_face_transformers.ipynb) tutorial. As I went through the code, I figured out that CategoricalCrossentropy was the only thing that looked a little out of place, so I tested with BinaryCrossentropy and now my model works much better.

I understand that Binary is just a case of Categorical and it should run fine but it doesn't :(

To test this out further, I ran it on the 20newsgroups data set but I couldn't notice any major difference between the losses.
See [code](https://github.com/theawless/ktrain/commit/db7ef44f72c6c889a57937dda65d100c620d1333) where I try to classify only `comp.graphics` and `soc.religion.christian` classes.

Using BinaryCrossentropy:
```
preprocessing train...
language: en
train sequence lengths:
	mean : 300
	95percentile : 884
	99percentile : 1531
Is Multi-Label? False
preprocessing test...
language: en
test sequence lengths:
	mean : 366
	95percentile : 1046
	99percentile : 3367
Using loss function:  <class 'tensorflow.python.keras.losses.BinaryCrossentropy'>
begin training using onecycle policy with max lr of 8e-05...
Epoch 1/2
99/99 [==============================] - 146s 1s/step - loss: 0.5194 - accuracy: 0.7586 - val_loss: 0.0962 - val_accuracy: 0.9720
Epoch 2/2
99/99 [==============================] - 130s 1s/step - loss: 0.0830 - accuracy: 0.9779 - val_loss: 0.0746 - val_accuracy: 0.9809
```

Using CategoricalCrossentropy:
```
preprocessing train...
language: en
train sequence lengths:
	mean : 300
	95percentile : 884
	99percentile : 1531
Is Multi-Label? False
preprocessing test...
language: en
test sequence lengths:
	mean : 366
	95percentile : 1046
	99percentile : 3367
Using loss function:  <class 'tensorflow.python.keras.losses.CategoricalCrossentropy'>
begin training using onecycle policy with max lr of 8e-05...
Epoch 1/2
148/148 [==============================] - 164s 1s/step - loss: 0.4146 - accuracy: 0.8130 - val_loss: 0.1166 - val_accuracy: 0.9695
Epoch 2/2
148/148 [==============================] - 150s 1s/step - loss: 0.0664 - accuracy: 0.9713 - val_loss: 0.0471 - val_accuracy: 0.9848
```