### PR TITLE
Fix showing wrong link to GraphSAGE paper

### DIFF
--- a/examples/graphs/cora_link_prediction-GraphSAGE.ipynb
+++ b/examples/graphs/cora_link_prediction-GraphSAGE.ipynb
@@ -138,7 +138,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphsage: GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf\n"
+      "graphsage: GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf\n"
      ]
     }
    ],

--- a/examples/graphs/cora_node_classification-GraphSAGE.ipynb
+++ b/examples/graphs/cora_node_classification-GraphSAGE.ipynb
@@ -138,7 +138,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphsage: GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf\n"
+      "graphsage: GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf\n"
      ]
     }
    ],

--- a/examples/graphs/hateful_twitter_users-GraphSAGE.ipynb
+++ b/examples/graphs/hateful_twitter_users-GraphSAGE.ipynb
@@ -476,7 +476,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphsage: GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf\n"
+      "graphsage: GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf\n"
      ]
     }
    ],

--- a/examples/graphs/pubmed_node_classification-GraphSAGE.ipynb
+++ b/examples/graphs/pubmed_node_classification-GraphSAGE.ipynb
@@ -207,7 +207,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphsage: GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf\n"
+      "graphsage: GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf\n"
      ]
     }
    ],

--- a/ktrain/graph/models.py
+++ b/ktrain/graph/models.py
@@ -9,10 +9,10 @@ from .. import utils as U
 
 GRAPHSAGE = 'graphsage'
 NODE_CLASSIFIERS = {
-        GRAPHSAGE: 'GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf'}
+        GRAPHSAGE: 'GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf'}
 
 LINK_PREDICTORS = {
-        GRAPHSAGE: 'GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf'}
+        GRAPHSAGE: 'GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf'}
 
 
 def print_node_classifiers():

--- a/tutorials/tutorial-07-graph-node_classification.ipynb
+++ b/tutorials/tutorial-07-graph-node_classification.ipynb
@@ -209,7 +209,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "graphsage: GraphSAGE:  http://arxiv.org/pdf/1607.01759.pdf\n"
+      "graphsage: GraphSAGE:  https://arxiv.org/pdf/1706.02216.pdf\n"
      ]
     }
    ],


### PR DESCRIPTION
While i checking graph notebook, i noticed GraphSAGE link leads to paper "Bag of Tricks for Efficient Text Classification" rather than "Inductive Representation Learning on Large Graphs". So i decided to fix the link on "graph.models" and noteooks.