### PR TITLE
Fixes for ImagePredictor.explain and TextPredictor.explain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             pip install ipython
             pip install tensorflow_cpu
             pip install jinja2==3.0.3 # eli5 dep issue
-            pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip
+            pip install https://github.com/amaiya/eli5-tf/archive/refs/heads/master.zip
       - name: Show installed pip dependencies
         run: pip freeze
       - name: Run tests 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        #language_version: python3.6 
-  #- repo: https://github.com/pycqa/isort
-    #rev: 5.10.1
-    #hooks:
-      #- id: isort
-        #name: isort (python)
+        language_version: python3.6 
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.6 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (python)
+        #language_version: python3.6 
+  #- repo: https://github.com/pycqa/isort
+    #rev: 5.10.1
+    #hooks:
+      #- id: isort
+        #name: isort (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Most recent releases are shown at the top. Each release shows:
 - **Changed**: Additional parameters, changes to inputs or outputs, etc
 - **Fixed**: Bug fixes that don't change documented behaviour
 
+## 0.31.4 (2022-08-01)
+
+### new:
+- N/A
+
+### changed
+- `TextPredictor.explain` and `ImagePredictor.explain` now use a different fork of `eli5`: `pip install https://github.com/amaiya/eli5-tf/archive/refs/heads/master.zip`
+
+### fixed:
+- Fixed `loss_fn_from_model` function to work with `DISABLE_V2_BEHAVIOR` properly
+- `TextPredictor.explain` and `ImagePredictor.explain` now work with `tensorflow>=2.9` and `scipy>=1.9` (due to new `eli5-tf` fork -- see above)
+
+
 ## 0.31.3 (2022-07-15)
 
 ### new:

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ The above should be all you need on Linux systems and cloud computing environmen
 # for graph module:
 pip install https://github.com/amaiya/stellargraph/archive/refs/heads/no_tf_dep_082.zip
 # for text.TextPredictor.explain and vision.ImagePredictor.explain:
-pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip
+pip install https://github.com/amaiya/eli5-tf/archive/refs/heads/master.zip
 # for tabular.TabularPredictor.explain:
 pip install shap
 # for text.zsl (ZeroShotClassifier), text.summarization, text.translation, text.speech:

--- a/ktrain/imports.py
+++ b/ktrain/imports.py
@@ -15,6 +15,7 @@ os.environ[
 ] = "8"  # suppress warning from NumExpr on machines with many CPUs
 
 # TensorFlow
+os.environ["TF_KERAS"] = "1"  # needed for eli5-tf
 SUPPRESS_DEP_WARNINGS = strtobool(os.environ.get("SUPPRESS_DEP_WARNINGS", "1"))
 if (
     SUPPRESS_DEP_WARNINGS

--- a/ktrain/text/predictor.py
+++ b/ktrain/text/predictor.py
@@ -132,17 +132,7 @@ class TextPredictor(Predictor):
         except:
             msg = (
                 "ktrain requires a forked version of eli5 to support tf.keras. "
-                + "Install with: pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
-            )
-            warnings.warn(msg)
-            return
-        if (
-            not hasattr(eli5, "KTRAIN_ELI5_TAG")
-            or eli5.KTRAIN_ELI5_TAG != KTRAIN_ELI5_TAG
-        ):
-            msg = (
-                "ktrain requires a forked version of eli5 to support tf.keras. It is either missing or not up-to-date. "
-                + "Uninstall the current version and install/re-install the fork with: pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
+                + "Install with: pip install https://github.com/amaiya/eli5-tf/archive/refs/heads/master.zip"
             )
             warnings.warn(msg)
             return

--- a/ktrain/utils.py
+++ b/ktrain/utils.py
@@ -55,7 +55,7 @@ def is_ktrain_dataset(data):
 
 def loss_fn_from_model(model):
     # dep_fix
-    if version.parse(tf.__version__) < version.parse("2.2"):
+    if version.parse(tf.__version__) < version.parse("2.2") or DISABLE_V2_BEHAVIOR:
         return model.loss_functions[0].fn
     else:  # TF 2.2.0
         return model.compiled_loss._get_loss_object(

--- a/ktrain/version.py
+++ b/ktrain/version.py
@@ -1,2 +1,2 @@
 __all__ = ["__version__"]
-__version__ = "0.31.3"
+__version__ = "0.31.4"

--- a/ktrain/vision/data.py
+++ b/ktrain/vision/data.py
@@ -2,6 +2,11 @@ from .. import utils as U
 from ..imports import *
 from .preprocessor import ImagePreprocessor
 
+try:
+    from tensorflow.keras.utils import img_to_array
+except ImportError:
+    img_to_array = keras.preprocessing.image.img_to_array
+
 
 def show_image(img_path):
     """
@@ -29,7 +34,7 @@ def show_random_images(img_folder, n=4, rows=1):
     for i in range(n):
         img_path = random.choice(fnames)
         img = keras.preprocessing.image.load_img(img_path)
-        x = keras.preprocessing.image.img_to_array(img)
+        x = img_to_array(img)
         x = x / 255.0
         ims.append(x)
     U.plots(ims, rows=rows)
@@ -55,7 +60,7 @@ def preview_data_aug(img_path, data_aug, rows=1, n=4):
     idg.preprocessing_function = None
 
     img = keras.preprocessing.image.load_img(img_path)
-    x = keras.preprocessing.image.img_to_array(img)
+    x = img_to_array(img)
     x = x / 255.0
     x = x.reshape((1,) + x.shape)
     i = 0
@@ -88,7 +93,7 @@ def preview_data_aug_OLD(img_path, data_aug, n=4):
     idg.preprocessing_function = None
 
     img = keras.preprocessing.image.load_img(img_path)
-    x = keras.preprocessing.image.img_to_array(img)
+    x = img_to_array(img)
     x = x / 255.0
     x = x.reshape((1,) + x.shape)
     i = 0

--- a/ktrain/vision/predictor.py
+++ b/ktrain/vision/predictor.py
@@ -32,7 +32,6 @@ class ImagePredictor(Predictor):
         Highlights image to explain prediction
         ```
         """
-
         try:
             import eli5
         except:

--- a/ktrain/vision/predictor.py
+++ b/ktrain/vision/predictor.py
@@ -32,34 +32,15 @@ class ImagePredictor(Predictor):
         Highlights image to explain prediction
         ```
         """
-        # if U.is_tf_keras():
-        # warnings.warn("currently_unsupported: explain() method is not available because tf.keras is "+\
-        # "not yet adequately supported by the eli5 library. You can switch to " +\
-        # "stand-alone Keras by setting os.environ['TF_KERAS']='0'" )
-        # return
 
         try:
             import eli5
         except:
             msg = (
                 "ktrain requires a forked version of eli5 to support tf.keras. "
-                + "Install with: pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
+                + "Install with: pip install https://github.com/amaiya/eli5-tf/archive/refs/heads/master.zip"
             )
             warnings.warn(msg)
-            return
-
-        # if not hasattr(eli5, 'KTRAIN'):
-        if (
-            not hasattr(eli5, "KTRAIN_ELI5_TAG")
-            or eli5.KTRAIN_ELI5_TAG != KTRAIN_ELI5_TAG
-        ):
-            warnings.warn(
-                "Since eli5 does not yet support tf.keras, ktrain uses a forked version of eli5.  "
-                + "We do not detect this forked version (or it is out-of-date), so predictor.explain may not work.  "
-                + "It will work if you uninstall the current version of eli5 and install "
-                + "the forked version:  "
-                + "pip install https://github.com/amaiya/eli5/archive/refs/heads/tfkeras_0_10_1.zip"
-            )
             return
 
         if not DISABLE_V2_BEHAVIOR:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ all_extras = [
     "librosa",  # for text.speech
     "torch==1.8.1",  # for qa, summarization, translation, zsl, speech
     "shap",  # for tabular.TabularPredictor.explain
-    "eli5 @ git+https://github@github.com/amaiya/eli5@tfkeras_0_10_1#egg=eli5",  # for explain in text/vision
+    "eli5 @ git+https://github@github.com/amaiya/eli5-tf@master#egg=eli5",  # for explain in text/vision
     "stellargraph @ git+https://github@github.com/amaiya/stellargraph@no_tf_dep_082#egg=stellargraph",  # for graph module
 ]
 # not included and checked/requested within-code:


### PR DESCRIPTION
Use new fork of `eli5` so that `explain` methods support `tensorflow>=2.9` and `scipy>=1.9`.  